### PR TITLE
Add non-carrier Note9 model number

### DIFF
--- a/app/src/main/java/app/attestation/auditor/AttestationActivity.java
+++ b/app/src/main/java/app/attestation/auditor/AttestationActivity.java
@@ -157,6 +157,7 @@ public class AttestationActivity extends AppCompatActivity {
             "SM-M205F",
             "SM-N960F",
             "SM-N960U",
+            "SM-N960U1",
             "SM-N970F",
             "SM-N970U",
             "SM-N975U",

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -103,6 +103,7 @@
     <string name="device_sm_m205f">Samsung Galaxy M20 (SM-M205F)</string>
     <string name="device_sm_n960f">Samsung Galaxy Note 9 (SM-N960F)</string>
     <string name="device_sm_n960u">Samsung Galaxy Note 9 (SM-N960U)</string>
+    <string name="device_sm_n960u1">Samsung Galaxy Note 9 (SM-N960U1)</string>
     <string name="device_sm_n970f">Samsung Galaxy Note 10 (SM-N970F)</string>
     <string name="device_sm_n970u">Samsung Galaxy Note 10 (SM-N970U)</string>
     <string name="device_sm_n975u">Samsung Galaxy Note 10+ (SM-N975U)</string>


### PR DESCRIPTION
This works fine on carrier Note9 firmwares, but not on phones flashed with the U1 firmware.