### PR TITLE
Migrate IntentService to JobIntentService

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,8 +27,13 @@
         </activity>
         <activity android:name=".QRScannerActivity" />
 
-        <service android:name=".GenerateAttestationService" />
-        <service android:name=".VerifyAttestationService" />
+        <service android:name=".GenerateAttestationService"
+            android:permission="android.permission.BIND_JOB_SERVICE"
+            android:exported="false" />
+
+        <service android:name=".VerifyAttestationService"
+            android:permission="android.permission.BIND_JOB_SERVICE"
+            android:exported="false" />
 
         <service android:name=".RemoteVerifyJob"
                 android:permission="android.permission.BIND_JOB_SERVICE"

--- a/app/src/main/java/app/attestation/auditor/AttestationActivity.java
+++ b/app/src/main/java/app/attestation/auditor/AttestationActivity.java
@@ -301,7 +301,7 @@ public class AttestationActivity extends AppCompatActivity {
         intent.putExtra(VerifyAttestationService.EXTRA_CHALLENGE_MESSAGE, auditorChallenge);
         intent.putExtra(VerifyAttestationService.EXTRA_SERIALIZED, serialized);
         intent.putExtra(VerifyAttestationService.EXTRA_PENDING_RESULT, pending);
-        startService(intent);
+        VerifyAttestationService.enqueueWork(this, intent);
     }
 
     private void generateAttestation(final byte[] challenge) {
@@ -311,7 +311,7 @@ public class AttestationActivity extends AppCompatActivity {
         final Intent intent = new Intent(this, GenerateAttestationService.class);
         intent.putExtra(GenerateAttestationService.EXTRA_CHALLENGE_MESSAGE, challenge);
         intent.putExtra(GenerateAttestationService.EXTRA_PENDING_RESULT, pending);
-        startService(intent);
+        GenerateAttestationService.enqueueWork(this, intent);
     }
 
     private void auditeeShowAttestation(final byte[] serialized) {

--- a/app/src/main/java/app/attestation/auditor/GenerateAttestationService.java
+++ b/app/src/main/java/app/attestation/auditor/GenerateAttestationService.java
@@ -1,14 +1,17 @@
 package app.attestation.auditor;
 
-import android.app.IntentService;
 import android.app.PendingIntent;
+import android.content.Context;
 import android.content.Intent;
 import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.core.app.JobIntentService;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
-public class GenerateAttestationService extends IntentService {
+public class GenerateAttestationService extends JobIntentService {
     private static final String TAG = "GenerateAttestationService";
 
     static final String EXTRA_CHALLENGE_MESSAGE = "app.attestation.auditor.CHALLENGE_MESSAGE";
@@ -23,12 +26,13 @@ public class GenerateAttestationService extends IntentService {
 
     static final int RESULT_CODE = 0;
 
-    public GenerateAttestationService() {
-        super(TAG);
-    }
+    static final int JOB_ID = 1001;
 
+    static void enqueueWork(Context context, Intent work) {
+        enqueueWork(context, GenerateAttestationService.class, JOB_ID, work);
+    }
     @Override
-    protected void onHandleIntent(final Intent intent) {
+    protected void onHandleWork(@NonNull Intent intent) {
         Log.d(TAG, "intent service started");
 
         if (intent.getBooleanExtra(EXTRA_CLEAR, false)) {
@@ -73,4 +77,9 @@ public class GenerateAttestationService extends IntentService {
             Log.e(TAG, "pending intent cancelled", e);
         }
     }
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+    }
+
 }

--- a/app/src/main/java/app/attestation/auditor/VerifyAttestationService.java
+++ b/app/src/main/java/app/attestation/auditor/VerifyAttestationService.java
@@ -1,16 +1,19 @@
 package app.attestation.auditor;
 
-import android.app.IntentService;
 import android.app.PendingIntent;
+import android.content.Context;
 import android.content.Intent;
 import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.core.app.JobIntentService;
 
 import java.io.IOException;
 import java.nio.BufferUnderflowException;
 import java.security.GeneralSecurityException;
 import java.util.zip.DataFormatException;
 
-public class VerifyAttestationService extends IntentService {
+public class VerifyAttestationService extends JobIntentService {
     private static final String TAG = "VerifyAttestationService";
 
     static final String EXTRA_CHALLENGE_MESSAGE = "app.attestation.auditor.CHALLENGE_MESSAGE";
@@ -25,12 +28,13 @@ public class VerifyAttestationService extends IntentService {
 
     static final int RESULT_CODE = 0;
 
-    public VerifyAttestationService() {
-        super(TAG);
-    }
+    static final int JOB_ID = 1001;
 
+    static void enqueueWork(Context context, Intent work) {
+        enqueueWork(context, VerifyAttestationService.class, JOB_ID, work);
+    }
     @Override
-    protected void onHandleIntent(final Intent intent) {
+    protected void onHandleWork(@NonNull Intent intent) {
         Log.d(TAG, "intent service started");
 
         if (intent.getBooleanExtra(EXTRA_CLEAR, false)) {
@@ -71,5 +75,9 @@ public class VerifyAttestationService extends IntentService {
         } catch (PendingIntent.CanceledException e) {
             Log.e(TAG, "pending intent cancelled", e);
         }
+    }
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
     }
 }


### PR DESCRIPTION
This is the first part of resolving #72 
IntentService is deprecated and it has been replaced by JobIntentService.

Not sure about the use of the explicit android:exported in AndroidManifest. 