### PR TITLE
Fix typo in securityLevelToString method

### DIFF
--- a/app/src/main/java/app/attestation/auditor/attestation/Attestation.java
+++ b/app/src/main/java/app/attestation/auditor/attestation/Attestation.java
@@ -83,7 +83,7 @@ public class Attestation {
             case KM_SECURITY_LEVEL_TRUSTED_ENVIRONMENT:
                 return "TEE";
             default:
-                return "Unkown";
+                return "Unknown";
         }
     }
 


### PR DESCRIPTION
The default case was missing a 'n'