### PR TITLE
target + compile for SDK 32, solve some deprecations, minor refactors

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,16 +25,16 @@ android {
         }
     }
 
-    compileSdk = 31
-    buildToolsVersion("31.0.0")
+    compileSdk = 32
+    buildToolsVersion = "32.0.0"
 
     defaultConfig {
         applicationId = "app.attestation.auditor"
         minSdk = 26
-        targetSdk = 31
+        targetSdk = 32
         versionCode = 41
         versionName = versionCode.toString()
-        resConfigs("en")
+        resourceConfigurations.addAll(listOf("en"))
     }
 
     buildTypes {
@@ -65,10 +65,10 @@ android {
 }
 
 dependencies {
-    implementation("androidx.appcompat:appcompat:1.4.0")
+    implementation("androidx.appcompat:appcompat:1.4.1")
     implementation("androidx.biometric:biometric:1.1.0")
     implementation("androidx.preference:preference:1.1.1")
-    implementation("com.google.android.material:material:1.4.0")
+    implementation("com.google.android.material:material:1.5.0")
     implementation("com.google.guava:guava:31.0.1-android")
     implementation("com.google.zxing:core:3.4.1")
     implementation("org.bouncycastle:bcpkix-jdk15to18:1.70")

--- a/app/src/main/java/app/attestation/auditor/QROverlay.kt
+++ b/app/src/main/java/app/attestation/auditor/QROverlay.kt
@@ -9,7 +9,7 @@ import android.graphics.PorterDuffXfermode
 import android.text.TextPaint
 import android.util.AttributeSet
 import android.view.View
-import app.attestation.auditor.R
+import kotlin.math.min
 
 class QROverlay(context: Context, attrs: AttributeSet?) : View(context, attrs) {
     companion object {
@@ -43,7 +43,7 @@ class QROverlay(context: Context, attrs: AttributeSet?) : View(context, attrs) {
     override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)
 
-        val dim = Math.min(width, height)
+        val dim = min(width, height)
         size = (dim * SIZE_FACTOR).toInt()
         tPaint.textSize = T_SIZE * SIZE_FACTOR * resources.displayMetrics.density
 

--- a/app/src/main/java/app/attestation/auditor/QRScannerActivity.kt
+++ b/app/src/main/java/app/attestation/auditor/QRScannerActivity.kt
@@ -15,7 +15,6 @@ import androidx.camera.core.ImageAnalysis
 import androidx.camera.core.MeteringPointFactory
 import androidx.camera.core.Preview
 import androidx.camera.core.SurfaceOrientedMeteringPointFactory
-import androidx.camera.core.CameraInfoUnavailableException
 import androidx.camera.lifecycle.ProcessCameraProvider
 import androidx.camera.view.CameraController
 import androidx.camera.view.LifecycleCameraController
@@ -27,7 +26,7 @@ class QRScannerActivity : AppCompatActivity() {
     companion object {
         const val EXTRA_SCAN_RESULT = "app.attestation.auditor.SCAN_RESULT"
         private val cameraSelector = CameraSelector.DEFAULT_BACK_CAMERA
-        private val autoCenterFocusDuration = 2000L
+        private const val autoCenterFocusDuration = 2000L
     }
 
     private val handler = Handler(Looper.getMainLooper())

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:7.0.4")
+        classpath("com.android.tools.build:gradle:7.1.0-rc01")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.10")
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=b586e04868a22fd817c8971330fec37e298f3242eb85c374181b12d637f80302
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionSha256Sum=07a1cd283d6cfe437eb08fe08936dc1af5f12946e67dc9f5e0a9f4b948ebfd3a
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-rc-1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
we need to use release candidate version of gradle wrapper and the plugin for SDK 32 at the moment. also solves log4j vulnerabilities in gradle wrapper (yes. really.). release candidate of Android Studio Bumblebee is recommended as well.

also some tiny refactors

Signed-off-by: June <june@eridan.me>