### PR TITLE
Ignore exception and remove needless parametres

### DIFF
--- a/app/src/main/java/app/attestation/auditor/AttestationProtocol.java
+++ b/app/src/main/java/app/attestation/auditor/AttestationProtocol.java
@@ -73,7 +73,6 @@ import app.attestation.auditor.attestation.AuthorizationList;
 import app.attestation.auditor.attestation.RootOfTrust;
 
 import static android.security.keystore.KeyProperties.DIGEST_SHA256;
-import static android.security.keystore.KeyProperties.KEY_ALGORITHM_EC;
 
 import static androidx.biometric.BiometricManager.Authenticators.BIOMETRIC_WEAK;
 import static androidx.biometric.BiometricManager.BIOMETRIC_SUCCESS;
@@ -1176,7 +1175,7 @@ class AttestationProtocol {
         if (useStrongBox) {
             enableStrongBox(builder);
         }
-        generateKeyPair(KEY_ALGORITHM_EC, builder.build());
+        generateKeyPair(builder.build());
     }
 
     static Certificate getCertificate(final KeyStore keyStore, final String alias)
@@ -1265,7 +1264,7 @@ class AttestationProtocol {
         if (useAttestKey) {
             setAttestKeyAlias(builder, attestKeystoreAlias);
         }
-        generateKeyPair(KEY_ALGORITHM_EC, builder.build());
+        generateKeyPair(builder.build());
 
         try {
             final byte[] fingerprint =
@@ -1417,7 +1416,7 @@ class AttestationProtocol {
         }
     }
 
-    static void generateKeyPair(final String algorithm, final KeyGenParameterSpec spec)
+    static void generateKeyPair(final KeyGenParameterSpec spec)
             throws NoSuchAlgorithmException, NoSuchProviderException,
             InvalidAlgorithmParameterException, IOException {
         // Handle RuntimeExceptions caused by a broken keystore. A common issue involves users
@@ -1428,7 +1427,7 @@ class AttestationProtocol {
         // being spammed to the Google Play error collection and causing it to think the app is
         // unreliable.
         try {
-            final KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance(algorithm,
+            final KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance(KeyProperties.KEY_ALGORITHM_EC,
                     "AndroidKeyStore");
             keyPairGenerator.initialize(spec);
             keyPairGenerator.generateKeyPair();

--- a/app/src/main/java/app/attestation/auditor/SubmitSampleJob.java
+++ b/app/src/main/java/app/attestation/auditor/SubmitSampleJob.java
@@ -36,8 +36,6 @@ import java.util.concurrent.Future;
 import java.util.Enumeration;
 import java.util.Properties;
 
-import static android.security.keystore.KeyProperties.KEY_ALGORITHM_EC;
-
 @TargetApi(26)
 public class SubmitSampleJob extends JobService {
     private static final String TAG = "SubmitSampleJob";
@@ -87,7 +85,7 @@ public class SubmitSampleJob extends JobService {
                         .setAlgorithmParameterSpec(new ECGenParameterSpec(AttestationProtocol.EC_CURVE))
                         .setDigests(AttestationProtocol.KEY_DIGEST)
                         .setAttestationChallenge("sample".getBytes());
-                AttestationProtocol.generateKeyPair(KEY_ALGORITHM_EC, builder.build());
+                AttestationProtocol.generateKeyPair(builder.build());
                 final Certificate[] certs = keyStore.getCertificateChain(KEYSTORE_ALIAS_SAMPLE);
                 keyStore.deleteEntry(KEYSTORE_ALIAS_SAMPLE);
 
@@ -95,7 +93,7 @@ public class SubmitSampleJob extends JobService {
                 if (Build.VERSION.SDK_INT >= 28) {
                     try {
                         builder.setIsStrongBoxBacked(true);
-                        AttestationProtocol.generateKeyPair(KEY_ALGORITHM_EC, builder.build());
+                        AttestationProtocol.generateKeyPair(builder.build());
                         strongBoxCerts = keyStore.getCertificateChain(KEYSTORE_ALIAS_SAMPLE);
                         keyStore.deleteEntry(KEYSTORE_ALIAS_SAMPLE);
                     } catch (final StrongBoxUnavailableException ignored) {

--- a/app/src/main/java/app/attestation/auditor/SystemProperties.java
+++ b/app/src/main/java/app/attestation/auditor/SystemProperties.java
@@ -10,7 +10,7 @@ class SystemProperties {
             try (Scanner scanner = new Scanner(process.getInputStream())) {
                 return scanner.nextLine().trim();
             }
-        } catch (IOException e) {}
+        } catch (IOException ignored) {}
         return def;
     }
 }


### PR DESCRIPTION
AttestationProtocol only supports EC keys and since we're going to support only modern devices only just have keyPairGenerator explicitly use EC only.

Signed-off-by: June <june@eridan.me>