### PR TITLE
Sync Attestation library with upstream CTS (android-cts-12.0_r3)

### DIFF
--- a/app/src/main/java/app/attestation/auditor/attestation/Asn1Utils.java
+++ b/app/src/main/java/app/attestation/auditor/attestation/Asn1Utils.java
@@ -38,7 +38,7 @@ import java.util.Date;
 import java.util.Enumeration;
 import java.util.Set;
 
-class Asn1Utils {
+public class Asn1Utils {
 
     public static int getIntegerFromAsn1(ASN1Encodable asn1Value)
             throws CertificateParsingException {
@@ -137,11 +137,30 @@ class Asn1Utils {
 
     public static boolean getBooleanFromAsn1(ASN1Encodable value)
             throws CertificateParsingException {
+        return getBooleanFromAsn1(value, true);
+    }
+
+    public static boolean getBooleanFromAsn1(ASN1Encodable value, boolean strictParsing)
+            throws CertificateParsingException {
         if (!(value instanceof ASN1Boolean)) {
             throw new CertificateParsingException(
                     "Expected boolean, found " + value.getClass().getName());
         }
-        return ((ASN1Boolean) value).isTrue();
+        ASN1Boolean booleanValue = (ASN1Boolean) value;
+
+        if (booleanValue.equals(ASN1Boolean.TRUE)) {
+            return true;
+        } else if (booleanValue.equals((ASN1Boolean.FALSE))) {
+            return false;
+        } else if (!strictParsing) {
+            // Value is not 0xFF nor 0x00, but some other non-zero value.
+            // This is invalid DER, but if we're not being strict,
+            // consider it true, otherwise fall through and throw exception
+            return true;
+        }
+
+        throw new CertificateParsingException(
+                "DER-encoded boolean values must contain either 0x00 or 0xFF");
     }
 
     private static int bigIntegerToInt(BigInteger bigInt) throws CertificateParsingException {

--- a/app/src/main/java/app/attestation/auditor/attestation/RootOfTrust.java
+++ b/app/src/main/java/app/attestation/auditor/attestation/RootOfTrust.java
@@ -42,6 +42,11 @@ public class RootOfTrust {
     private final byte[] verifiedBootHash;
 
     public RootOfTrust(ASN1Encodable asn1Encodable) throws CertificateParsingException {
+        this(asn1Encodable, true);
+    }
+
+    public RootOfTrust(ASN1Encodable asn1Encodable, boolean strictParsing)
+            throws CertificateParsingException {
         if (!(asn1Encodable instanceof ASN1Sequence)) {
             throw new CertificateParsingException("Expected sequence for root of trust, found "
                     + asn1Encodable.getClass().getName());
@@ -50,7 +55,8 @@ public class RootOfTrust {
         ASN1Sequence sequence = (ASN1Sequence) asn1Encodable;
         verifiedBootKey =
                 Asn1Utils.getByteArrayFromAsn1(sequence.getObjectAt(VERIFIED_BOOT_KEY_INDEX));
-        deviceLocked = Asn1Utils.getBooleanFromAsn1(sequence.getObjectAt(DEVICE_LOCKED_INDEX));
+        deviceLocked = Asn1Utils.getBooleanFromAsn1(
+                sequence.getObjectAt(DEVICE_LOCKED_INDEX), strictParsing);
         verifiedBootState =
                 Asn1Utils.getIntegerFromAsn1(sequence.getObjectAt(VERIFIED_BOOT_STATE_INDEX));
         if (sequence.size() < 4) {
@@ -96,7 +102,9 @@ public class RootOfTrust {
     @Override
     public String toString() {
         return "\nVerified boot Key: " +
-                BaseEncoding.base16().encode(verifiedBootKey) +
+                (verifiedBootKey != null ?
+                        BaseEncoding.base64().encode(verifiedBootKey) :
+                        "null") +
                 "\nDevice locked: " +
                 deviceLocked +
                 "\nVerified boot state: " +


### PR DESCRIPTION
Signed-off-by: June <june@eridan.me>

Notable changes/additions:

- Strict mode / strictParsing
- KeyMaster Strongbox Security Level (Software, TEE, Strongbox) (KM_SECURITY_LEVEL_STRONG_BOX)
- New overloaded method AttestationApplicationId uses Android PackageManager and PM Signature
- unexpectedExtensionOids (?)
- getRootOfTrust and getSecurityLevel

I have tested a local attestation on my Pixel 5 (stock OS) and Pixel 6 Pro (GrapheneOS) and both are successful in the initial pairing (orange) and sequential attestations (green).

AttestationServer: https://github.com/GrapheneOS/AttestationServer/pull/161