### PR TITLE
Add a OS security patch check before submitting a sample

### DIFF
--- a/app/src/main/java/app/attestation/auditor/SubmitSampleJob.java
+++ b/app/src/main/java/app/attestation/auditor/SubmitSampleJob.java
@@ -35,6 +35,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.Enumeration;
 import java.util.Properties;
+import java.time.format.DateTimeFormatter;
+import java.time.LocalDate;
 
 @TargetApi(26)
 public class SubmitSampleJob extends JobService {
@@ -46,6 +48,12 @@ public class SubmitSampleJob extends JobService {
     private static final int NOTIFICATION_ID = 2;
     private static final String NOTIFICATION_CHANNEL_ID = "sample_submission";
 
+    // We only want to allow samples submitted by (mostly) non-EOL devices to make filtering
+    // and prioritisation easier so we'll get the current date, subtract 5 days to account for some days
+    // before a security patch is released (usually the 1st - 5th of new month) remove "-DD" and compare it to
+    // ro.build.version.security_patch (outputs YYYY-MM-DD but we also remove "-DD" there too).
+    // This isn't foolproof, but it should help.
+    private static final String OS_PATCH_LEVEL_MINIMUM = LocalDate.now().minusDays(5).format(DateTimeFormatter.ofPattern("uuuu-MM"));
     private static final String KEYSTORE_ALIAS_SAMPLE = "sample_attestation_key";
 
     private static final ExecutorService executor = Executors.newSingleThreadExecutor();

--- a/app/src/main/java/app/attestation/auditor/SubmitSampleJob.java
+++ b/app/src/main/java/app/attestation/auditor/SubmitSampleJob.java
@@ -144,6 +144,18 @@ public class SubmitSampleJob extends JobService {
                 }
             } catch (final GeneralSecurityException | IOException e) {
                 Log.e(TAG, "submit failure", e);
+                final Context context = SubmitSampleJob.this;
+                final NotificationManager manager = context.getSystemService(NotificationManager.class);
+                final NotificationChannel channel = new NotificationChannel(NOTIFICATION_CHANNEL_ID,
+                        context.getString(R.string.sample_submission_notification_channel),
+                        NotificationManager.IMPORTANCE_LOW);
+                manager.createNotificationChannel(channel);
+                manager.notify(NOTIFICATION_ID, new Notification.Builder(context, NOTIFICATION_CHANNEL_ID)
+                        .setContentTitle(context.getString(R.string.sample_submission_notification_title_failure))
+                        .setContentText(context.getString(R.string.sample_submission_notification_content_failure))
+                        .setShowWhen(true)
+                        .setSmallIcon(R.drawable.baseline_cloud_upload_white_24)
+                        .build());
                 jobFinished(params, true);
                 return;
             } finally {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,6 +41,8 @@
     <string name="sample_submission_notification_channel">Sample submission</string>
     <string name="sample_submission_notification_title">Submitted sample data</string>
     <string name="sample_submission_notification_content">Successfully submitted sample data.</string>
+    <string name="sample_submission_notification_title_failure">Failed submitting sample data</string>
+    <string name="sample_submission_notification_content_failure">Failed to submit sample data.</string>
 
     <string name="scanner_label">Scan QR code shown on the other device.</string>
     <string name="verifying_attestation">Verifying attestation…</string>


### PR DESCRIPTION
This will help us filter out EOL devices.

The check consists of getting today's date, subtracting 5 days to account for new months of no security patch (1st - 5th), and only doing a string comparison of the year and month on the OS security patch level property (e.g. 2022-05) (ro.build.version.security_patch).

We also add a failure notification of the sample submission and other general submission failures. We only will not reschedule it if the user has a mismatching security patch level.