### PR TITLE
Target SDK 12L/12.1

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -31,7 +31,7 @@ android {
     defaultConfig {
         applicationId = "app.attestation.auditor"
         minSdk = 26
-        targetSdk = 31
+        targetSdk = 32
         versionCode = 44
         versionName = versionCode.toString()
         resourceConfigurations.add("en")


### PR DESCRIPTION
GrapheneOS is now on 12.1.

Signed-off-by: June <june@eridan.me>