### PR TITLE
Exclude extraneous bouncycastle .properties files

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -63,6 +63,10 @@ android {
         dex {
             useLegacyPackaging = false
         }
+        resources.excludes.addAll(listOf(
+            "org/bouncycastle/pqc/**.properties",
+            "org/bouncycastle/x509/**.properties",
+        ))
     }
 }
 


### PR DESCRIPTION
As in explained in https://github.com/GrapheneOS/Apps/pull/229, the update to bouncycastle 1.72 increased the release APK size by ~4 MiB due to .properties files added for bouncycastle's new Picnic and SIKE implementations. We can exclude them since we're not using those algorithms.