### PR TITLE
feat: add an option to immediately remote verify

### DIFF
--- a/app/src/main/java/app/attestation/auditor/AttestationActivity.java
+++ b/app/src/main/java/app/attestation/auditor/AttestationActivity.java
@@ -63,8 +63,10 @@ public class AttestationActivity extends AppCompatActivity {
 
     private static final int PERMISSIONS_REQUEST_CAMERA = 0;
     private static final int PERMISSIONS_REQUEST_POST_NOTIFICATIONS_REMOTE_VERIFY = 1;
+
     private static final int PERMISSIONS_REQUEST_POST_NOTIFICATIONS_SUBMIT_SAMPLE = 2;
 
+    private static final int PERMISSIONS_REQUEST_POST_NOTIFICATIONS_IMMEDIATE_REMOTE_VERIFY = 3;
     private static final ExecutorService executor = Executors.newSingleThreadExecutor();
 
     private ActivityAttestationBinding binding;
@@ -468,6 +470,9 @@ public class AttestationActivity extends AppCompatActivity {
             }
         } else if (requestCode == PERMISSIONS_REQUEST_POST_NOTIFICATIONS_REMOTE_VERIFY) {
             QRScannerActivityLauncher.launch(new Intent(this, QRScannerActivity.class));
+        } else if (requestCode == PERMISSIONS_REQUEST_POST_NOTIFICATIONS_IMMEDIATE_REMOTE_VERIFY) {
+            RemoteVerifyJob.schedule(this, -1);
+            snackbar.setText(R.string.remote_verify_now).show();
         } else if (requestCode == PERMISSIONS_REQUEST_POST_NOTIFICATIONS_SUBMIT_SAMPLE) {
             SubmitSampleJob.schedule(this);
             snackbar.setText(R.string.schedule_submit_sample_success).show();
@@ -549,7 +554,7 @@ public class AttestationActivity extends AppCompatActivity {
         else if (itemId == R.id.action_remote_verify_now) {
             if (checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
                 requestPermissions(new String[]{Manifest.permission.POST_NOTIFICATIONS},
-                        PERMISSIONS_REQUEST_POST_NOTIFICATIONS_REMOTE_VERIFY);
+                        PERMISSIONS_REQUEST_POST_NOTIFICATIONS_IMMEDIATE_REMOTE_VERIFY);
             } else {
                 RemoteVerifyJob.schedule(this, -1);
                 snackbar.setText(R.string.remote_verify_now).show();

--- a/app/src/main/java/app/attestation/auditor/AttestationActivity.java
+++ b/app/src/main/java/app/attestation/auditor/AttestationActivity.java
@@ -502,6 +502,7 @@ public class AttestationActivity extends AppCompatActivity {
         menu.findItem(R.id.action_enable_remote_verify)
                 .setEnabled(isSupportedAuditee && !isRemoteVerifyEnabled);
         menu.findItem(R.id.action_disable_remote_verify).setEnabled(isRemoteVerifyEnabled);
+        menu.findItem(R.id.action_remote_verify_now).setEnabled(isRemoteVerifyEnabled);
         menu.findItem(R.id.action_submit_sample).setEnabled(canSubmitSample &&
                 !SubmitSampleJob.isScheduled(this));
         return true;
@@ -544,7 +545,19 @@ public class AttestationActivity extends AppCompatActivity {
             stage = Stage.EnableRemoteVerify;
             startQrScanner();
             return true;
-        } else if (itemId == R.id.action_disable_remote_verify) {
+        }
+        else if (itemId == R.id.action_remote_verify_now) {
+            if (checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
+                requestPermissions(new String[]{Manifest.permission.POST_NOTIFICATIONS},
+                        PERMISSIONS_REQUEST_POST_NOTIFICATIONS_SUBMIT_SAMPLE);
+            } else {
+                RemoteVerifyJob.schedule(this, -1);
+                snackbar.setText(R.string.remote_verify_now).show();
+            }
+            return true;
+        }
+
+        else if (itemId == R.id.action_disable_remote_verify) {
             new AlertDialog.Builder(this)
                     .setMessage(getString(R.string.action_disable_remote_verify) + "?")
                     .setPositiveButton(R.string.disable, (dialogInterface, i) -> {

--- a/app/src/main/java/app/attestation/auditor/AttestationActivity.java
+++ b/app/src/main/java/app/attestation/auditor/AttestationActivity.java
@@ -549,7 +549,7 @@ public class AttestationActivity extends AppCompatActivity {
         else if (itemId == R.id.action_remote_verify_now) {
             if (checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
                 requestPermissions(new String[]{Manifest.permission.POST_NOTIFICATIONS},
-                        PERMISSIONS_REQUEST_POST_NOTIFICATIONS_SUBMIT_SAMPLE);
+                        PERMISSIONS_REQUEST_POST_NOTIFICATIONS_REMOTE_VERIFY);
             } else {
                 RemoteVerifyJob.schedule(this, -1);
                 snackbar.setText(R.string.remote_verify_now).show();

--- a/app/src/main/java/app/attestation/auditor/RemoteVerifyJob.java
+++ b/app/src/main/java/app/attestation/auditor/RemoteVerifyJob.java
@@ -39,6 +39,8 @@ public class RemoteVerifyJob extends JobService {
     private static final String TAG = "RemoteVerifyJob";
     private static final int PERIODIC_JOB_ID = 0;
     private static final int FIRST_RUN_JOB_ID = 1;
+
+    private static final int FIRE_ONCE_JOB_ID = 2;
     static final String DOMAIN = "attestation.app";
     private static final String CHALLENGE_URL = "https://" + DOMAIN + "/challenge";
     private static final String VERIFY_URL = "https://" + DOMAIN + "/verify";
@@ -115,13 +117,24 @@ public class RemoteVerifyJob extends JobService {
                 throw new RuntimeException("job schedule failed");
             }
         }
-        final JobInfo.Builder builder = new JobInfo.Builder(PERIODIC_JOB_ID, serviceName)
+        final JobInfo.Builder builder = scheduleNow ?
+                new JobInfo.Builder(FIRE_ONCE_JOB_ID, serviceName)
+                        .setPersisted(true)
+                        .setRequiredNetworkType(JobInfo.NETWORK_TYPE_ANY)
+                : new JobInfo.Builder(PERIODIC_JOB_ID, serviceName)
                 .setPersisted(true)
                 .setRequiredNetworkType(JobInfo.NETWORK_TYPE_ANY)
+<<<<<<< HEAD
                 .setEstimatedNetworkBytes(ESTIMATED_DOWNLOAD_BYTES, ESTIMATED_UPLOAD_BYTES);
 
         if(!scheduleNow) {
             builder.setPeriodic(intervalMillis, flexMillis);
+=======
+                .setPeriodic(intervalMillis, flexMillis);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            builder.setEstimatedNetworkBytes(ESTIMATED_DOWNLOAD_BYTES, ESTIMATED_UPLOAD_BYTES);
+>>>>>>> 9a0a5f1 (review changes)
         }
         if (scheduler.schedule(builder.build()) == JobScheduler.RESULT_FAILURE) {
             throw new RuntimeException("job schedule failed");

--- a/app/src/main/java/app/attestation/auditor/RemoteVerifyJob.java
+++ b/app/src/main/java/app/attestation/auditor/RemoteVerifyJob.java
@@ -124,18 +124,9 @@ public class RemoteVerifyJob extends JobService {
                 : new JobInfo.Builder(PERIODIC_JOB_ID, serviceName)
                 .setPersisted(true)
                 .setRequiredNetworkType(JobInfo.NETWORK_TYPE_ANY)
-<<<<<<< HEAD
-                .setEstimatedNetworkBytes(ESTIMATED_DOWNLOAD_BYTES, ESTIMATED_UPLOAD_BYTES);
-
-        if(!scheduleNow) {
-            builder.setPeriodic(intervalMillis, flexMillis);
-=======
+                .setEstimatedNetworkBytes(ESTIMATED_DOWNLOAD_BYTES, ESTIMATED_UPLOAD_BYTES)
                 .setPeriodic(intervalMillis, flexMillis);
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-            builder.setEstimatedNetworkBytes(ESTIMATED_DOWNLOAD_BYTES, ESTIMATED_UPLOAD_BYTES);
->>>>>>> 9a0a5f1 (review changes)
-        }
         if (scheduler.schedule(builder.build()) == JobScheduler.RESULT_FAILURE) {
             throw new RuntimeException("job schedule failed");
         }

--- a/app/src/main/res/menu/menu_attestation.xml
+++ b/app/src/main/res/menu/menu_attestation.xml
@@ -14,6 +14,9 @@
     <item android:id="@+id/action_disable_remote_verify"
             android:title="@string/action_disable_remote_verify"
             app:showAsAction="never" />
+    <item android:id="@+id/action_remote_verify_now"
+        android:title="@string/action_remote_verify_now"
+        app:showAsAction="never" />
     <item android:id="@+id/action_submit_sample"
             android:title="@string/action_submit_sample"
             app:showAsAction="never" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,11 +20,13 @@
     <string name="action_clear_auditor">Clear Auditor pairings</string>
     <string name="action_enable_remote_verify">Enable remote verification</string>
     <string name="action_disable_remote_verify">Disable remote verification</string>
+    <string name="action_remote_verify_now">Remote verify Now</string>
     <string name="action_submit_sample">Submit sample data</string>
     <string name="action_help">Help</string>
 
     <string name="enable_remote_verify_success">Scheduled regular remote verification</string>
     <string name="disable_remote_verify_success">Disabled remote verification</string>
+    <string name="remote_verify_now">Scheduled immeidate remote verification</string>
     <string name="schedule_submit_sample_success">Scheduled submitting sample data</string>
     <string name="clear_auditee_pairings_success">Cleared Auditee pairings</string>
     <string name="clear_auditee_pairings_failure">Failed to fully clear Auditee pairings</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,13 +20,13 @@
     <string name="action_clear_auditor">Clear Auditor pairings</string>
     <string name="action_enable_remote_verify">Enable remote verification</string>
     <string name="action_disable_remote_verify">Disable remote verification</string>
-    <string name="action_remote_verify_now">Remote verify Now</string>
+    <string name="action_remote_verify_now">Remote verify now</string>
     <string name="action_submit_sample">Submit sample data</string>
     <string name="action_help">Help</string>
 
     <string name="enable_remote_verify_success">Scheduled regular remote verification</string>
     <string name="disable_remote_verify_success">Disabled remote verification</string>
-    <string name="remote_verify_now">Scheduled immeidate remote verification</string>
+    <string name="remote_verify_now">Scheduled immediate remote verification</string>
     <string name="schedule_submit_sample_success">Scheduled submitting sample data</string>
     <string name="clear_auditee_pairings_success">Cleared Auditee pairings</string>
     <string name="clear_auditee_pairings_failure">Failed to fully clear Auditee pairings</string>


### PR DESCRIPTION
This PR adds an option in the menu bar that says "Remote verify now". It will schedule an immediate job that performs the Remote Verification Job instead of the regular periodic trigger.

Fixes #197 

