### PR TITLE
gradle: Trust -javadoc, -sources, and gradle source files

### DIFF
--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -3,6 +3,11 @@
    <configuration>
       <verify-metadata>true</verify-metadata>
       <verify-signatures>false</verify-signatures>
+      <trusted-artifacts>
+         <trust file=".*-javadoc[.]jar" regex="true"/>
+         <trust file=".*-sources[.]jar" regex="true"/>
+         <trust file="gradle-.*-src[.]zip" regex="true"/>
+      </trusted-artifacts>
    </configuration>
    <components>
       <component group="androidx.activity" name="activity" version="1.6.0">


### PR DESCRIPTION
When these files are left untrusted, gradle sync would fail in Android Studio. The only files that we need to be verified are the compiled libraries that we're pulling.

Taken from the gradle documentation - https://docs.gradle.org/8.7/userguide/dependency_verification.html#sec:skipping-javadocs
