### PR TITLE
Fix lint overdraw warning

### DIFF
--- a/app/src/main/res/layout/activity_attestation.xml
+++ b/app/src/main/res/layout/activity_attestation.xml
@@ -3,7 +3,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="?attr/colorSurface"
     tools:context="app.attestation.auditor.AttestationActivity">
 
     <com.google.android.material.appbar.AppBarLayout

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -11,6 +11,8 @@
         <item name="colorSurfaceContainer">@color/grapheneSurfaceContainerColor</item>
 
         <item name="popupMenuStyle">@style/GraphenePopup</item>
+
+        <item name="background">@null</item>
     </style>
 
     <style name="GraphenePopup" parent="Widget.Material3.PopupMenu">


### PR DESCRIPTION
Turns out you're supposed to set the background on the app theme to null if you want to make sure that dynamic colors are applied in a way that avoids potential overdraw.

Addresses - https://github.com/GrapheneOS/Auditor/pull/275#issuecomment-2336538169