### PR TITLE
Improve accuracy on minimum auto reboot timeout duration possible in …

### DIFF
--- a/app/src/main/java/app/attestation/auditor/AttestationProtocol.java
+++ b/app/src/main/java/app/attestation/auditor/AttestationProtocol.java
@@ -1138,7 +1138,7 @@ class AttestationProtocol {
 
         final int autoRebootSeconds = securityStateExt.autoRebootSeconds();
         final String autoRebootValueString;
-        if (autoRebootSeconds > 20) {
+        if (autoRebootSeconds >= 20) {
             final Duration duration = Duration.ofSeconds(autoRebootSeconds);
             final StringBuilder autoRebootValueStrBuilder = new StringBuilder();
 


### PR DESCRIPTION
…the OS.

Comparison should be >= 20 seconds rather than > 20 seconds.