### PR TITLE
Validate remote-verify QR before persisting account state

### DIFF
--- a/app/src/main/java/app/attestation/auditor/AttestationActivity.java
+++ b/app/src/main/java/app/attestation/auditor/AttestationActivity.java
@@ -123,16 +123,21 @@ public class AttestationActivity extends AppCompatActivity {
                                 snackbar.setText(R.string.scanned_invalid_account_qr_code).show();
                                 return;
                             }
-                            PreferenceManager.getDefaultSharedPreferences(this).edit()
-                                    .putLong(RemoteVerifyJob.KEY_USER_ID, Long.parseLong(values[1]))
-                                    .putString(RemoteVerifyJob.KEY_SUBSCRIBE_KEY, values[2])
-                                    .apply();
+                            final long userId;
+                            final int interval;
                             try {
-                                RemoteVerifyJob.schedule(this, Integer.parseInt(values[3]));
-                                snackbar.setText(R.string.enable_remote_verify_success).show();
+                                userId = Long.parseLong(values[1]);
+                                interval = Integer.parseInt(values[3]);
                             } catch (final NumberFormatException e) {
                                 snackbar.setText(R.string.scanned_invalid_account_qr_code).show();
+                                return;
                             }
+                            PreferenceManager.getDefaultSharedPreferences(this).edit()
+                                    .putLong(RemoteVerifyJob.KEY_USER_ID, userId)
+                                    .putString(RemoteVerifyJob.KEY_SUBSCRIBE_KEY, values[2])
+                                    .apply();
+                            RemoteVerifyJob.schedule(this, interval);
+                            snackbar.setText(R.string.enable_remote_verify_success).show();
                         } else {
                             throw new RuntimeException("received unexpected scan result");
                         }


### PR DESCRIPTION
Hardens the `Stage.EnableRemoteVerify` branch of the QR scan result handler in `AttestationActivity` so that a malformed account QR can no longer crash the app or leave remote verification in a half-enabled state.

**Problem**

In AttestationActivity.java the handler did:

```java
PreferenceManager.getDefaultSharedPreferences(this).edit()
        .putLong(RemoteVerifyJob.KEY_USER_ID, Long.parseLong(values[1]))
        .putString(RemoteVerifyJob.KEY_SUBSCRIBE_KEY, values[2])
        .apply();
try {
    RemoteVerifyJob.schedule(this, Integer.parseInt(values[3]));
    snackbar.setText(R.string.enable_remote_verify_success).show();
} catch (final NumberFormatException e) {
    snackbar.setText(R.string.scanned_invalid_account_qr_code).show();
}
```

Two issues:

1. `Long.parseLong(values[1])` is outside the `try`. Any QR of the form `attestation.app <non-numeric> …` triggers an uncaught `NumberFormatException` in the `ActivityResultLauncher` lambda and crashes the activity. Only the interval field was guarded.
2. The user id and subscribe key are written to `SharedPreferences` before the interval is parsed and the job is scheduled. If the interval is malformed, the prefs are already persisted, so:
   - `RemoteVerifyJob.isEnabled()` returns `true`, hiding the "Enable remote verification" button in `onResume()`.
   - `RemoteVerifyJob.isScheduled()` returns `false` — no job runs.
   - The user has to use the "Disable remote verification" menu item to recover.

**Fix**

Parse both `userId` and `interval` inside a single `try` / `catch (NumberFormatException)`. Only after both parse successfully are preferences committed and the job scheduled. Behavior on a valid QR is unchanged.