### PR TITLE
Remove debug log of remote verify enrollment QR contents

### DIFF
--- a/app/src/main/java/app/attestation/auditor/AttestationActivity.java
+++ b/app/src/main/java/app/attestation/auditor/AttestationActivity.java
@@ -117,7 +117,6 @@ public class AttestationActivity extends AppCompatActivity {
                             handleAttestation(contentsBytes);
                         } else if (stage == Stage.EnableRemoteVerify) {
                             stage = Stage.None;
-                            Log.d(TAG, "account: " + contents);
                             final String[] values = contents.split(" ");
                             if (values.length < 4 || !RemoteVerifyJob.DOMAIN.equals(values[0])) {
                                 snackbar.setText(R.string.scanned_invalid_account_qr_code).show();


### PR DESCRIPTION
Suggesting to remove `Log.d(TAG, "account: " + contents)` in the `EnableRemoteVerify` flow.
The scanned QR includes the subscribe key used to authorize pairing in the initial remote verification request.
`Log.d` is not stripped in release builds and is reachable via logcat/bugreports.