### PR TITLE
Disable backup of pairing data

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
     <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES" />
 
     <application android:label="@string/app_name"
+            android:allowBackup="false"
             android:useEmbeddedDex="true"
             android:networkSecurityConfig="@xml/network_security_config"
             android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
Closes #326

Pairing data is currently included in cloud backup, this excludes it while leaving device-to-device transfers unaffected.