### PR TITLE
fix: reset stage when scanner is cancelled

### DIFF
--- a/app/src/main/java/app/attestation/auditor/AttestationActivity.java
+++ b/app/src/main/java/app/attestation/auditor/AttestationActivity.java
@@ -145,6 +145,8 @@ public class AttestationActivity extends AppCompatActivity {
                             stage = Stage.None;
                         }
                     }
+                } else if (stage == Stage.Auditee || stage == Stage.EnableRemoteVerify) {
+                    stage = Stage.None;
                 }
             });
 


### PR DESCRIPTION
Reset attestation UI stage when the user backs out of the camera scanner without RESULT_OK.

Fixes #323

## Test plan
- [ ] Review diff against issue
- [ ] Run project lint/tests if applicable
